### PR TITLE
Fixing apache installation for Ubuntu Saucy (13.10)

### DIFF
--- a/tasks/apache2.yml
+++ b/tasks/apache2.yml
@@ -36,4 +36,16 @@
   copy:
     src: apache2/security
     dest: /etc/apache2/conf.d/security
+  when: ansible_distribution_release != 'saucy'
   notify: Restart apache
+
+- name: Tighten Apache security (Saucy)
+  copy:
+    src: apache2/security
+    dest: /etc/apache2/conf-available/security
+  when: ansible_distribution_release == 'saucy'
+  notify: Restart apache
+
+- name: activate security (Saucy)
+  file: src=/etc/apache2/conf-available/security dest=/etc/apache2/conf-enabled/security state=link
+  when: ansible_distribution_release == 'saucy'

--- a/tasks/create-sites.yml
+++ b/tasks/create-sites.yml
@@ -1,13 +1,8 @@
 ---
 - name: Create shared srv folder
   file:
-    path: /srv/www/shared
+    path: '{{apache_www_folder}}/shared'
     state: directory
-
-- name: Create blocking robots.txt
-  copy:
-    src: robots.txt
-    dest: /srv/www/shared/robots.txt
 
 - name: Create home folders
   user:
@@ -17,16 +12,18 @@
     generate_ssh_key: yes
     password: ''
   with_items: vhost_sites
+  when: item.user != 'www-data'
 
 - name: Add SSH public keys
   authorized_key:
     user: "{{ item['user'] }}"
     key: "{{ lookup('file', '/tmp/combined_ssh.' + inventory_hostname) }}"
+  when: item.user != 'www-data'
   with_items: vhost_sites
 
 - name: Create public_html folders
   file:
-    path: /srv/www/{{ item['host'] }}/public_html
+    path: "{{apache_www_folder}}/{{ item.host }}/public_html"
     state: directory
     owner: "{{ item['user'] }}"
     group: "{{ item['group'] }}"
@@ -34,16 +31,17 @@
 
 - name: Create public_html symlinks
   file:
-    src: /srv/www/{{ item['host'] }}/public_html
+    src: "{{apache_www_folder}}/{{ item['host'] }}/public_html"
     dest: /home/{{ item['user'] }}/public_html
     state: link
     owner: "{{ item['user'] }}"
     group: "{{ item['group'] }}"
   with_items: vhost_sites
+  when: item.user != 'www-data'
 
 - name: Create log folders
   file:
-    path: /srv/www/{{ item['host'] }}/logs
+    path: "{{apache_www_folder}}/{{ item['host'] }}/logs"
     state: directory
     owner: "{{ item['user'] }}"
     group: "{{ item['group'] }}"
@@ -51,12 +49,13 @@
 
 - name: Create logs symlinks
   file:
-    src: /srv/www/{{ item['host'] }}/logs
+    src: "{{apache_www_folder}}/{{ item['host'] }}/logs"
     dest: /home/{{ item['user'] }}/logs
     state: link
     owner: "{{ item['user'] }}"
     group: "{{ item['group'] }}"
   with_items: vhost_sites
+  when: item.user != 'www-data'
 
 - name: Create apache2 vhosts
   template:

--- a/tasks/delete-sites.yml
+++ b/tasks/delete-sites.yml
@@ -8,7 +8,7 @@
 
 - name: Delete public_html folders
   file:
-    path: /srv/www/{{ item['host'] }}
+    path: "{{apache_www_folder}}/{{ item['host'] }}"
     state: absent
   with_items: deleted_vhost_sites
 

--- a/tasks/disable-sites.yml
+++ b/tasks/disable-sites.yml
@@ -1,11 +1,4 @@
 ---
-- name: Delete SSH public keys
-  authorized_key:
-    user: "{{ item['user'] }}"
-    key: "{{ lookup('file', '/tmp/combined_ssh.' + inventory_hostname) }}"
-    state: absent
-  with_items: disabled_vhost_sites
-
 - name: Disable apache2 vhosts
   file:
     path: /etc/apache2/sites-enabled/{{ item['host'] }}.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,13 +2,6 @@
 - include: apache2.yml
 - include: php.yml
 
-- name: Create combined SSH file
-  assemble:
-    src: roles/apache/files/ssh/keys
-    dest: /tmp/combined_ssh.{{inventory_hostname}}
-  delegate_to: 127.0.0.1
-  sudo: no
-
 - include: create-sites.yml
   when: vhost_sites is defined
 - include: disable-sites.yml
@@ -16,9 +9,3 @@
 - include: delete-sites.yml
   when: deleted_vhost_sites is defined
 
-- name: Delete combined SSH file
-  file:
-    path: /tmp/combined_ssh.{{inventory_hostname}}
-    state: absent
-  delegate_to: 127.0.0.1
-  sudo: no

--- a/templates/apache2/vhost.conf.j2
+++ b/templates/apache2/vhost.conf.j2
@@ -5,10 +5,10 @@
     ServerAlias                           {{ alias }}
 {% endfor %}
 
-    DocumentRoot                 /srv/www/{{ item['host'] }}/public_html/
-    ErrorLog                     /srv/www/{{ item['host'] }}/logs/error.log
-    CustomLog                    /srv/www/{{ item['host'] }}/logs/access.log combined
-    php_admin_value error_log    /srv/www/{{ item['host'] }}/logs/php.error.log
+    DocumentRoot                 {{apache_www_folder}}/{{ item['host'] }}/public_html/
+    ErrorLog                     {{apache_www_folder}}/{{ item['host'] }}/logs/error.log
+    CustomLog                    {{apache_www_folder}}/{{ item['host'] }}/logs/access.log combined
+    php_admin_value error_log    {{apache_www_folder}}/{{ item['host'] }}/logs/php.error.log
 
     <IfModule mpm_itk_module>
         AssignUserId {{ item['user'] }} {{ item['group'] }}

--- a/templates/apache2/vhost.conf.j2
+++ b/templates/apache2/vhost.conf.j2
@@ -17,7 +17,7 @@
       Order allow,deny
       Allow from all
       Require all granted
-      Options Indexes FollowSymLinks
+      Options FollowSymLinks FollowSymLinks
       AllowOverride All
     </Directory>
 

--- a/templates/apache2/vhost.conf.j2
+++ b/templates/apache2/vhost.conf.j2
@@ -13,6 +13,13 @@
     <IfModule mpm_itk_module>
         AssignUserId {{ item['user'] }} {{ item['group'] }}
     </IfModule>
+    <Directory {{apache_www_folder}}/{{item.host}}/public_html>
+      Order allow,deny
+      Allow from all
+      Require all granted
+      Options Indexes FollowSymLinks
+      AllowOverride All
+    </Directory>
 
     <IfModule mod_expires.c>
         ExpiresActive On

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -43,6 +43,9 @@ apache_modules:
 apache_host: "127.0.0.1"
 apache_port: "80"
 apache_ssl_port: "443"
+create_combined_ssh: true
+
+apache_www_folder: /srv/www
 
 
 php_packages:


### PR DESCRIPTION
On 13.10, the apache conf.d is no more. I added a conditional for that case. That won't handle future Apaches (14.04+), and I didn't know a better way to handle how to set the variables based on the Ansible distribution. 
Besides, one has to remove the php5-suhosin package from the php list, but that can be handled by the client.

Thanks for the work!
